### PR TITLE
Fixing incorrect substring indexes

### DIFF
--- a/Conversions/HexToRGB.js
+++ b/Conversions/HexToRGB.js
@@ -1,7 +1,7 @@
 function hexStringToRGB (hexString) {
-  var r = (hexString.substring(1, 3)).toUpperCase()
-  var g = hexString.substring(3, 5).toUpperCase()
-  var b = hexString.substring(5, 7).toUpperCase()
+  var r = hexString.substring(0, 2)
+  var g = hexString.substring(2, 4)
+  var b = hexString.substring(4, 6)
 
   r = parseInt(r, 16)
   g = parseInt(g, 16)
@@ -11,4 +11,4 @@ function hexStringToRGB (hexString) {
   return obj
 }
 
-console.log(hexStringToRGB('javascript rock !!'))
+console.log(hexStringToRGB('ffffff'))


### PR DESCRIPTION
Substring indexes were all off by 1, creating an incorrect output.
Also removed unnecessary `toUpperCase()` calls.

# Welcome to JavaScript community

### **Describe your change:**

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new JavaScript files are placed inside an existing directory.
* [ ] All filenames should use the UpperCamelCase (PascalCase) style.  There should be no spaces in filenames.
     **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
