### PR TITLE
Add Get Numbers of Days of a Month

### DIFF
--- a/Timing-Functions/GetMonthDays.js
+++ b/Timing-Functions/GetMonthDays.js
@@ -1,0 +1,33 @@
+/**
+  function that takes month number and its year and returns the number of days within it
+  * @param monthNumber.
+  * @param year.
+  e.g.: mahfoudh.arous@gmail.com -> true
+  e.g.: mahfoudh.arous.com ->false
+*/
+
+const getMonthDays = (monthNumber, year) => {
+  const the31DaysMonths = [1, 3, 5, 7, 8, 10, 12]
+  const the30DaysMonths = [4, 6, 9, 11]
+
+  if (!the31DaysMonths.includes(monthNumber) && !the30DaysMonths.includes(monthNumber) &&
+    (monthNumber !== 2)
+  ) {
+    throw new TypeError('Invalid Month Number.')
+  }
+
+  if (the31DaysMonths.includes(monthNumber)) { return 31 }
+
+  if (the30DaysMonths.includes(monthNumber)) { return 30 }
+
+  // Check for Leap year
+  if (year % 4 === 0) {
+    if ((year % 100 !== 0) || (year % 100 === 0 && year % 400 === 0)) {
+      return 29
+    }
+  }
+
+  return 28
+}
+
+export { getMonthDays }

--- a/Timing-Functions/GetMonthDays.test.js
+++ b/Timing-Functions/GetMonthDays.test.js
@@ -1,0 +1,19 @@
+import { getMonthDays } from './GetMonthDays'
+
+describe('Get the Days of a Month', () => {
+  it('expects to return 28', () => {
+    expect(getMonthDays(2, 2018)).toEqual(28)
+  })
+
+  it('expects to return 30', () => {
+    expect(getMonthDays(6, 254)).toEqual(30)
+  })
+
+  it('expects to return 29', () => {
+    expect(getMonthDays(2, 2024)).toEqual(29)
+  })
+
+  it('expects to throw a type error', () => {
+    expect(() => { getMonthDays(13, 2020) }).toThrow('Invalid Month Number.')
+  })
+})


### PR DESCRIPTION
# Welcome to JavaScript community

Adding a function that get the number of days of a month, given its number and its year.

### **Describe your change:**

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new JavaScript files are placed inside an existing directory.
* [x] All filenames should use the UpperCamelCase (PascalCase) style.  There should be no spaces in filenames.
     **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
