### PR TITLE
Modify ValidateEmail.js to accept all suffixes not just '.com'

### DIFF
--- a/Maths/Pow.js
+++ b/Maths/Pow.js
@@ -1,0 +1,11 @@
+// Returns the value of x to the power of y
+
+const pow = (x, y) => {
+  let result = 1
+  for (let i = 1; i <= y; i++) {
+    result *= x
+  }
+  return result
+}
+
+export { pow }

--- a/String/ValidateEmail.js
+++ b/String/ValidateEmail.js
@@ -2,6 +2,7 @@
   function that takes a string input and return either it is true of false
   a valid email address
   e.g.: mahfoudh.arous@gmail.com -> true
+  e.g.: mahfoudh.arous@helsinki.edu -> true
   e.g.: mahfoudh.arous.com ->false
 */
 
@@ -9,11 +10,8 @@ const validateEmail = (str) => {
   if (str === '' || str === null) {
     throw new TypeError('Email Address String Null or Empty.')
   }
-  if (str.startsWith('@') === true || !str.includes('@') || !str.endsWith('.com')) {
-    return false
-  }
 
-  return true
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(str)
 }
 
 export { validateEmail }

--- a/String/test/ValidateEmail.test.js
+++ b/String/test/ValidateEmail.test.js
@@ -1,4 +1,4 @@
-import { validateEmail } from './ValidateEmail'
+import { validateEmail } from '../ValidateEmail'
 
 describe('Validation of an Email Address', () => {
   it('expects to return false', () => {
@@ -11,6 +11,10 @@ describe('Validation of an Email Address', () => {
 
   it('expects to return true', () => {
     expect(validateEmail('mahfoudh.arous@gmail.com')).toEqual(true)
+  })
+
+  it('expects to return true', () => {
+    expect(validateEmail('icristianbaciu@.helsinki.edu')).toEqual(true)
   })
 
   it('expects to throw a type error', () => {


### PR DESCRIPTION
# Welcome to JavaScript community

### **Describe your change:**

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new JavaScript files are placed inside an existing directory.
* [x] All filenames should use the UpperCamelCase (PascalCase) style.  There should be no spaces in filenames.
     **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
