### PR TITLE
Quality-of-Life: Ignore intelliJ workspace folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# intelliJ workspace folder
+.idea


### PR DESCRIPTION
### **Describe your change:**

Simple quality-of-life fix: Ignore intelliJ's workspace folder. intelliJ is my daily driver for working with code. Everytime I clone a repo and open up its contents in intelliJ, the IDE will automatically create the `.idea` folder for storing project-specific settings etc.

### **Checklist:**

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.

### **Not applicable items from the checklist (since I only changed the .gitignore file):**

* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new JavaScript files are placed inside an existing directory.
* [ ] All filenames should use the UpperCamelCase (PascalCase) style.  There should be no spaces in filenames.
     **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
