### PR TITLE
Algorithm to calculate the Arithmetic Geometric Mean

### DIFF
--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -9,6 +9,8 @@
 
  export const agm = (a, g) => {
   if (a === g) return a; //avoid rounding errors, and increase efficiency
+  if (a === Infinity && g === 0) return NaN;
+  if (Object.is(a, -0) && !Object.is(g, -0)) return 0;
   let x; //temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -9,16 +9,18 @@
 
  export const agm = (a, g) => {
   if (a === g) return a; //avoid rounding errors, and increase efficiency
-  let x; //temp var, for detecting rounding differences between `sqrt` and division
+  let x; //temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]
   } while (a !== x && !isNaN(a));
   /*
   `x !== a` ensures the return value has full precision,
-  and prevents infinite loops caused by rounding errors (no need for "epsilon").
+  and prevents infinite loops caused by rounding differences between `div` and `sqrt` (no need for "epsilon").
+  If we were to compare `a` with `g`, some input combinations (not all) can cause an infinite loop,
+  because the rounding mode never changes at runtime.
   Precision is not the same as accuracy, but they're related.
   This function isn't always 100% accurate (round-errors), but at least is more than 95% accurate.
-  `!isNaN(x)` prevents infinite loops caused by invalid inputs like: negatives, NaNs and both Infinities.
+  `!isNaN(x)` prevents infinite loops caused by invalid inputs like: negatives, NaNs and Infinities.
   */
-	return a
+  return a;
 }

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -8,9 +8,9 @@
  */
 
  export const agm = (a, g) => {
-  if (a === g) return a; //avoid rounding errors, and increase efficiency
   if (a === Infinity && g === 0) return NaN;
   if (Object.is(a, -0) && !Object.is(g, -0)) return 0;
+  if (a === g) return a; //avoid rounding errors, and increase efficiency
   let x; //temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -10,7 +10,8 @@
  export const agm = (a, g) => {
   if (a === g) return a; //avoid rounding errors, and increase efficiency
   if (a === Infinity && g === 0) return NaN;
-  if (Object.is(a, -0) && !Object.is(g, -0)) return 0;
+  if (Object.is(a, -0) && Object.is(g, -0)) return a;
+  if (a === 0 || g === 0) return 0;
   let x; //temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -7,14 +7,14 @@
  * @see [AGM](https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean)
  */
 
- export const agm = (a, g) => {
-  if (a === Infinity && g === 0) return NaN;
-  if (Object.is(a, -0) && !Object.is(g, -0)) return 0;
-  if (a === g) return a; //avoid rounding errors, and increase efficiency
-  let x; //temp var
+export const agm = (a, g) => {
+  if (a === Infinity && g === 0) return NaN
+  if (Object.is(a, -0) && !Object.is(g, -0)) return 0
+  if (a === g) return a // avoid rounding errors, and increase efficiency
+  let x // temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]
-  } while (a !== x && !isNaN(a));
+  } while (a !== x && !isNaN(a))
   /*
   `x !== a` ensures the return value has full precision,
   and prevents infinite loops caused by rounding differences between `div` and `sqrt` (no need for "epsilon").
@@ -24,5 +24,5 @@
   This function isn't always 100% accurate (round-errors), but at least is more than 95% accurate.
   `!isNaN(x)` prevents infinite loops caused by invalid inputs like: negatives, NaNs and Infinities.
   */
-  return a;
+  return a
 }

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -1,0 +1,24 @@
+/**
+ * @function agm
+ * @description This finds the Arithmetic-Geometric Mean between any 2 numbers.
+ * @param {Number} a - 1st number, also used to store Arithmetic Mean.
+ * @param {Number} g - 2nd number, also used to store Geometric Mean.
+ * @return {Number} - AGM of both numbers.
+ * @see [AGM](https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean)
+ */
+
+ export const agm = (a, g) => {
+  if (a === g) return a; //avoid rounding errors, and increase efficiency
+  let x; //temp var, for detecting rounding differences between `sqrt` and division
+  do {
+    [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]
+  } while (a !== x && !isNaN(a));
+  /*
+  `x !== a` ensures the return value has full precision,
+  and prevents infinite loops caused by rounding errors (no need for "epsilon").
+  Precision is not the same as accuracy, but they're related.
+  This function isn't always 100% accurate (round-errors), but at least is more than 95% accurate.
+  `!isNaN(x)` prevents infinite loops caused by invalid inputs like: negatives, NaNs and both Infinities.
+  */
+	return a
+}

--- a/Maths/ArithmeticGeometricMean.js
+++ b/Maths/ArithmeticGeometricMean.js
@@ -10,8 +10,7 @@
  export const agm = (a, g) => {
   if (a === g) return a; //avoid rounding errors, and increase efficiency
   if (a === Infinity && g === 0) return NaN;
-  if (Object.is(a, -0) && Object.is(g, -0)) return a;
-  if (a === 0 || g === 0) return 0;
+  if (Object.is(a, -0) && !Object.is(g, -0)) return 0;
   let x; //temp var
   do {
     [a, g, x] = [(a + g) / 2, Math.sqrt(a * g), a]

--- a/Maths/test/ArithmeticGeometricMean.test.js
+++ b/Maths/test/ArithmeticGeometricMean.test.js
@@ -9,10 +9,10 @@ describe('Tests for AGM', () => {
     expect(agm.length).toEqual(2)
   })
 
-  const m = 0x100; //scale for rand
+  const m = 0x100 //scale for rand
 
   it('should return NaN if any or all params has a negative argument', () => {
-    //I multiplied by minus one, because the sign inversion is more clearly visible
+    // I multiplied by minus one, because the sign inversion is more clearly visible
     expect(agm(-1 * Math.random() * m, Math.random() * m)).toBe(NaN)
     expect(agm(Math.random() * m, -1 * Math.random() * m)).toBe(NaN)
     expect(agm(-1 * Math.random() * m, -1 * Math.random() * m)).toBe(NaN)
@@ -46,11 +46,11 @@ describe('Tests for AGM', () => {
   })
 
   it('should return an accurate approximation of the AGM between 2 valid input args', () => {
-    //all the constants are provided by WolframAlpha (and truncated)
-    expect(agm(1, 2)).toBeCloseTo(1.45679103104690686918643238326508197497386394)
-    expect(agm(2, 256)).toBeCloseTo(64.45940719438666959866654349832508984802270)
-    expect(agm(55555, 34)).toBeCloseTo(9933.404723955199530518734848979633709254)
-    //test "unsafe" numbers
+    // all the constants are provided by WolframAlpha
+    expect(agm(1, 2)).toBeCloseTo(1.4567910310469068)
+    expect(agm(2, 256)).toBeCloseTo(64.45940719438667)
+    expect(agm(55555, 34)).toBeCloseTo(9933.4047239552)
+    // test "unsafe" numbers
     expect(agm(2 ** 48, 3 ** 27)).toBeCloseTo(88506556379265.7)
   })
 })

--- a/Maths/test/ArithmeticGeometricMean.test.js
+++ b/Maths/test/ArithmeticGeometricMean.test.js
@@ -9,7 +9,7 @@ describe('Tests for AGM', () => {
     expect(agm.length).toEqual(2)
   })
 
-  const m = 0x100 //scale for rand
+  const m = 0x100 // scale for rand
 
   it('should return NaN if any or all params has a negative argument', () => {
     // I multiplied by minus one, because the sign inversion is more clearly visible

--- a/Maths/test/ArithmeticGeometricMean.test.js
+++ b/Maths/test/ArithmeticGeometricMean.test.js
@@ -21,26 +21,26 @@ describe('Tests for AGM', () => {
   it('should return Infinity if any arg is Infinity and the other is not 0', () => {
     expect(agm(Math.random() * m + 1, Infinity)).toEqual(Infinity)
     expect(agm(Infinity, Math.random() * m + 1)).toEqual(Infinity)
-    expect(agm(Infinity, Infinity).toEqual(Infinity))
+    expect(agm(Infinity, Infinity)).toEqual(Infinity)
   })
 
   it('should return NaN if some arg is Infinity and the other is 0', () => {
-    expect(agm(0, Infinity).toBe(NaN))
-    expect(agm(Infinity, 0).toBe(NaN))
+    expect(agm(0, Infinity)).toBe(NaN)
+    expect(agm(Infinity, 0)).toBe(NaN)
   })
 
   it('should return +0 if any or all args are +0 or -0, and return -0 if all are -0', () => {
     expect(agm(Math.random() * m, -0)).toBe(0)
     expect(agm(0, Math.random() * m)).toBe(0)
-    expect(agm(0, -0).toBe(0))
-    expect(agm(-0, 0).toBe(0))
-    expect(agm(-0, -0).toBe(-0))
+    expect(agm(0, -0)).toBe(0)
+    expect(agm(-0, 0)).toBe(0)
+    expect(agm(-0, -0)).toBe(-0)
   })
 
   it('should return NaN if any or all args are NaN', () => {
     expect(agm(Math.random() * m, NaN)).toBe(NaN)
     expect(agm(NaN, Math.random() * m)).toBe(NaN)
-    expect(agm(NaN, NaN).toBe(NaN))
+    expect(agm(NaN, NaN)).toBe(NaN)
   })
 
   it('should return an accurate approximation of the AGM between 2 valid input args', () => {
@@ -49,6 +49,6 @@ describe('Tests for AGM', () => {
     expect(agm(2, 256)).toBeCloseTo(64.4594071943866695986665434983250898480227029006463800294306182)
     expect(agm(55555, 34)).toBeCloseTo(9933.40472395519953051873484897963370925448369441581220656590)
     //test "unsafe" numbers
-    expect(agm(2 ** 48, 3 ** 27).toBeCloseTo(88506556379265.712723873253375677194780))
+    expect(agm(2 ** 48, 3 ** 27)).toBeCloseTo(88506556379265.712723873253375677194780)
   })
 })

--- a/Maths/test/ArithmeticGeometricMean.test.js
+++ b/Maths/test/ArithmeticGeometricMean.test.js
@@ -30,8 +30,10 @@ describe('Tests for AGM', () => {
   })
 
   it('should return +0 if any or all args are +0 or -0, and return -0 if all are -0', () => {
-    expect(agm(Math.random() * m, -0)).toBe(0)
+    expect(agm(Math.random() * m, 0)).toBe(0)
     expect(agm(0, Math.random() * m)).toBe(0)
+    expect(agm(Math.random() * m, -0)).toBe(0)
+    expect(agm(-0, Math.random() * m)).toBe(0)
     expect(agm(0, -0)).toBe(0)
     expect(agm(-0, 0)).toBe(0)
     expect(agm(-0, -0)).toBe(-0)
@@ -44,11 +46,11 @@ describe('Tests for AGM', () => {
   })
 
   it('should return an accurate approximation of the AGM between 2 valid input args', () => {
-    //all the constants are provided by WolframAlpha
-    expect(agm(1, 2)).toBeCloseTo(1.4567910310469068691864323832650819749738639432213055907941723832)
-    expect(agm(2, 256)).toBeCloseTo(64.4594071943866695986665434983250898480227029006463800294306182)
-    expect(agm(55555, 34)).toBeCloseTo(9933.40472395519953051873484897963370925448369441581220656590)
+    //all the constants are provided by WolframAlpha (and truncated)
+    expect(agm(1, 2)).toBeCloseTo(1.45679103104690686918643238326508197497386394)
+    expect(agm(2, 256)).toBeCloseTo(64.45940719438666959866654349832508984802270)
+    expect(agm(55555, 34)).toBeCloseTo(9933.404723955199530518734848979633709254)
     //test "unsafe" numbers
-    expect(agm(2 ** 48, 3 ** 27)).toBeCloseTo(88506556379265.712723873253375677194780)
+    expect(agm(2 ** 48, 3 ** 27)).toBeCloseTo(88506556379265.7)
   })
 })

--- a/Maths/test/ArithmeticGeometricMean.test.js
+++ b/Maths/test/ArithmeticGeometricMean.test.js
@@ -1,0 +1,54 @@
+import { agm } from '../ArithmeticGeometricMean.js'
+
+describe('Tests for AGM', () => {
+  it('should be a function', () => {
+    expect(typeof agm).toEqual('function')
+  })
+
+  it('number of parameters should be 2', () => {
+    expect(agm.length).toEqual(2)
+  })
+
+  const m = 0x100; //scale for rand
+
+  it('should return NaN if any or all params has a negative argument', () => {
+    //I multiplied by minus one, because the sign inversion is more clearly visible
+    expect(agm(-1 * Math.random() * m, Math.random() * m)).toBe(NaN)
+    expect(agm(Math.random() * m, -1 * Math.random() * m)).toBe(NaN)
+    expect(agm(-1 * Math.random() * m, -1 * Math.random() * m)).toBe(NaN)
+  })
+
+  it('should return Infinity if any arg is Infinity and the other is not 0', () => {
+    expect(agm(Math.random() * m + 1, Infinity)).toEqual(Infinity)
+    expect(agm(Infinity, Math.random() * m + 1)).toEqual(Infinity)
+    expect(agm(Infinity, Infinity).toEqual(Infinity))
+  })
+
+  it('should return NaN if some arg is Infinity and the other is 0', () => {
+    expect(agm(0, Infinity).toBe(NaN))
+    expect(agm(Infinity, 0).toBe(NaN))
+  })
+
+  it('should return +0 if any or all args are +0 or -0, and return -0 if all are -0', () => {
+    expect(agm(Math.random() * m, -0)).toBe(0)
+    expect(agm(0, Math.random() * m)).toBe(0)
+    expect(agm(0, -0).toBe(0))
+    expect(agm(-0, 0).toBe(0))
+    expect(agm(-0, -0).toBe(-0))
+  })
+
+  it('should return NaN if any or all args are NaN', () => {
+    expect(agm(Math.random() * m, NaN)).toBe(NaN)
+    expect(agm(NaN, Math.random() * m)).toBe(NaN)
+    expect(agm(NaN, NaN).toBe(NaN))
+  })
+
+  it('should return an accurate approximation of the AGM between 2 valid input args', () => {
+    //all the constants are provided by WolframAlpha
+    expect(agm(1, 2)).toBeCloseTo(1.4567910310469068691864323832650819749738639432213055907941723832)
+    expect(agm(2, 256)).toBeCloseTo(64.4594071943866695986665434983250898480227029006463800294306182)
+    expect(agm(55555, 34)).toBeCloseTo(9933.40472395519953051873484897963370925448369441581220656590)
+    //test "unsafe" numbers
+    expect(agm(2 ** 48, 3 ** 27).toBeCloseTo(88506556379265.712723873253375677194780))
+  })
+})


### PR DESCRIPTION
Added an algorithm to compute/find the Arithmetic-Geometric Mean between 2 numbers `a` and `g`. I thought it would be a good idea since it shows how to compute at full precision without an `epsilon` comparison, and there's already an Arithmetic Mean so I added this for completeness.

# Welcome to JavaScript community

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)


### Describe your change:

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new JavaScript files are placed inside an existing directory.
* [x] All filenames should use the UpperCamelCase (PascalCase) style.  There should be no spaces in filenames.
     **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
