### PR TITLE
Fix wiggle sort

### DIFF
--- a/Sorts/SimplifiedWiggleSort.js
+++ b/Sorts/SimplifiedWiggleSort.js
@@ -12,14 +12,12 @@ export const simplifiedWiggleSort = function (arr) {
   let median = quickSelectSearch(arr, Math.floor(arr.length / 2.0))
   median = median[Math.floor(arr.length / 2.0)]
 
-  console.log(median)
   const sorted = new Array(arr.length)
 
   let smallerThanMedianIndx = 0
   let greaterThanMedianIndx = arr.length - 1 - (arr.length % 2)
 
   for (let i = 0; i < arr.length; i++) {
-    console.log(sorted)
     if (arr[i] > median) {
       sorted[greaterThanMedianIndx] = arr[i]
       greaterThanMedianIndx -= 2
@@ -39,13 +37,13 @@ export const simplifiedWiggleSort = function (arr) {
 
 // Implementation of wiggle sort
 
-// console.log(simplifiedWiggleSort([3, 5, 2, 1, 6, 4]))
+// simplifiedWiggleSort([3, 5, 2, 1, 6, 4])
 // [ 3, 5, 2, 6, 1, 4 ]
-// console.log(simplifiedWiggleSort([3, 5, 2, 2, 0, 2]))
-//  [ 0, 5, 2, 3, 2, 2 ]
-// console.log(simplifiedWiggleSort([1, 1, 1, 2, 2]))
+// simplifiedWiggleSort([3, 5, 2, 2, 0, 2])
+// [ 0, 5, 2, 3, 2, 2 ]
+// simplifiedWiggleSort([1, 1, 1, 2, 2])
 // [ 1, 2, 1, 2, 1 ]
-// console.log(simplifiedWiggleSort([1, 1, 2, 2, 2]))
+// simplifiedWiggleSort([1, 1, 2, 2, 2])
 // [ 1, 2, 1, 2, 2 ]
-// console.log(simplifiedWiggleSort([3, 5, 6, 1]))
+// simplifiedWiggleSort([3, 5, 6, 1])
 // [ 3, 6, 1, 5 ]

--- a/Sorts/SimplifiedWiggleSort.js
+++ b/Sorts/SimplifiedWiggleSort.js
@@ -34,16 +34,3 @@ export const simplifiedWiggleSort = function (arr) {
 
   return sorted
 }
-
-// Implementation of wiggle sort
-
-// simplifiedWiggleSort([3, 5, 2, 1, 6, 4])
-// [ 3, 5, 2, 6, 1, 4 ]
-// simplifiedWiggleSort([3, 5, 2, 2, 0, 2])
-// [ 0, 5, 2, 3, 2, 2 ]
-// simplifiedWiggleSort([1, 1, 1, 2, 2])
-// [ 1, 2, 1, 2, 1 ]
-// simplifiedWiggleSort([1, 1, 2, 2, 2])
-// [ 1, 2, 1, 2, 2 ]
-// simplifiedWiggleSort([3, 5, 6, 1])
-// [ 3, 6, 1, 5 ]

--- a/Sorts/SimplifiedWiggleSort.js
+++ b/Sorts/SimplifiedWiggleSort.js
@@ -7,7 +7,7 @@
  */
 import { quickSelectSearch } from '../Search/QuickSelectSearch.js'
 
-export const wiggleSort = function (arr) {
+export const simplifiedWiggleSort = function (arr) {
   // find Median using QuickSelect
   let median = quickSelectSearch(arr, Math.floor(arr.length / 2.0))
   median = median[Math.floor(arr.length / 2.0)]
@@ -39,13 +39,13 @@ export const wiggleSort = function (arr) {
 
 // Implementation of wiggle sort
 
-// console.log(wiggleSort([3, 5, 2, 1, 6, 4]))
+// console.log(simplifiedWiggleSort([3, 5, 2, 1, 6, 4]))
 // [ 3, 5, 2, 6, 1, 4 ]
-// console.log(wiggleSort([3, 5, 2, 2, 0, 2]))
+// console.log(simplifiedWiggleSort([3, 5, 2, 2, 0, 2]))
 //  [ 0, 5, 2, 3, 2, 2 ]
-// console.log(wiggleSort([1, 1, 1, 2, 2]))
+// console.log(simplifiedWiggleSort([1, 1, 1, 2, 2]))
 // [ 1, 2, 1, 2, 1 ]
-// console.log(wiggleSort([1, 1, 2, 2, 2]))
+// console.log(simplifiedWiggleSort([1, 1, 2, 2, 2]))
 // [ 1, 2, 1, 2, 2 ]
-// console.log(wiggleSort([3, 5, 6, 1]))
+// console.log(simplifiedWiggleSort([3, 5, 6, 1]))
 // [ 3, 6, 1, 5 ]

--- a/Sorts/WiggleSort.js
+++ b/Sorts/WiggleSort.js
@@ -39,10 +39,13 @@ export const wiggleSort = function (arr) {
 
 // Implementation of wiggle sort
 
-console.log(wiggleSort([3, 5, 2, 1, 6, 4]))
+// console.log(wiggleSort([3, 5, 2, 1, 6, 4]))
 // [ 3, 5, 2, 6, 1, 4 ]
-console.log(wiggleSort([3, 5, 2, 2, 0, 2]))
+// console.log(wiggleSort([3, 5, 2, 2, 0, 2]))
 //  [ 0, 5, 2, 3, 2, 2 ]
-console.log(wiggleSort([1, 1, 1, 2, 2]))
+// console.log(wiggleSort([1, 1, 1, 2, 2]))
 // [ 1, 2, 1, 2, 1 ]
-console.log(wiggleSort([1, 1, 2, 2, 2]))
+// console.log(wiggleSort([1, 1, 2, 2, 2]))
+// [ 1, 2, 1, 2, 2 ]
+// console.log(wiggleSort([3, 5, 6, 1]))
+// [ 3, 6, 1, 5 ]

--- a/Sorts/WiggleSort.js
+++ b/Sorts/WiggleSort.js
@@ -1,21 +1,48 @@
 /*
  * Wiggle sort sorts the array into a wave like array.
- * An array ‘arr[0..n-1]’ is sorted in wave form if arr[0] >= arr[1] <= arr[2] >= arr[3] <= arr[4] >= …..
- *
+ * An array ‘arr[0..n-1]’ is sorted in wave form if arr[0] <= arr[1] >= arr[2] <= arr[3] >= arr[4] <= …..
+ * KEEP IN MIND: there are also more strict definitions of wiggle sort which use
+ * the rule arr[0] < arr[1] > arr[2] < arr[3] > arr[4] < … but this function
+ * allows for equality of values next to each other.
  */
+import { quickSelectSearch } from '../Search/QuickSelectSearch.js'
 
 export const wiggleSort = function (arr) {
-  for (let i = 0; i < arr.length; ++i) {
-    const shouldNotBeLessThan = i % 2
-    const isLessThan = arr[i] < arr[i + 1]
-    if (shouldNotBeLessThan && isLessThan) {
-      [arr[i], arr[i + 1]] = [arr[i + 1], arr[i]]
+  // find Median using QuickSelect
+  let median = quickSelectSearch(arr, Math.floor(arr.length / 2.0))
+  median = median[Math.floor(arr.length / 2.0)]
+
+  console.log(median)
+  const sorted = new Array(arr.length)
+
+  let smallerThanMedianIndx = 0
+  let greaterThanMedianIndx = arr.length - 1 - (arr.length % 2)
+
+  for (let i = 0; i < arr.length; i++) {
+    console.log(sorted)
+    if (arr[i] > median) {
+      sorted[greaterThanMedianIndx] = arr[i]
+      greaterThanMedianIndx -= 2
+    } else {
+      if (smallerThanMedianIndx < arr.length) {
+        sorted[smallerThanMedianIndx] = arr[i]
+        smallerThanMedianIndx += 2
+      } else {
+        sorted[greaterThanMedianIndx] = arr[i]
+        greaterThanMedianIndx -= 2
+      }
     }
   }
-  return arr
+
+  return sorted
 }
 
 // Implementation of wiggle sort
 
-// > wiggleSort([3, 5, 2, 1, 6, 4])
+console.log(wiggleSort([3, 5, 2, 1, 6, 4]))
 // [ 3, 5, 2, 6, 1, 4 ]
+console.log(wiggleSort([3, 5, 2, 2, 0, 2]))
+//  [ 0, 5, 2, 3, 2, 2 ]
+console.log(wiggleSort([1, 1, 1, 2, 2]))
+// [ 1, 2, 1, 2, 1 ]
+console.log(wiggleSort([1, 1, 2, 2, 2]))

--- a/Sorts/test/SimplifiedWiggleSort.test.js
+++ b/Sorts/test/SimplifiedWiggleSort.test.js
@@ -1,0 +1,29 @@
+import { simplifiedWiggleSort } from '../SimplifiedWiggleSort.js'
+
+describe('simplified wiggle sort', () => {
+  test('given array of symbols [\'b\', \'a\', \'c\'] return wiggle sorted array [\'a\', \'c\', \'b\']', () => {
+    const src = ['a', 'b', 'c']
+    expect(simplifiedWiggleSort(src)).toEqual(['a', 'c', 'b'])
+  })
+
+  test('wiggle sort with duplicates, even array', () => {
+    const src = [2, 2, 1, 3]
+    expect(simplifiedWiggleSort(src)).toEqual([1, 3, 2, 2])
+  })
+
+  test('wiggle sort with duplicates, odd array', () => {
+    const src = [1, 1, 1, 2, 4]
+    expect(simplifiedWiggleSort(src)).toEqual([1, 4, 1, 2, 1])
+  })
+
+  test('simplified wiggle sort for [3, 5, 6, 1]', () => {
+    const src = [3, 5, 6, 1]
+    expect(simplifiedWiggleSort(src)).toEqual([3, 6, 1, 5])
+  })
+
+  test('simplified wiggle sort for [3, 3, 5, 1] (equal values next to ' +
+    'each other can not be avoided in simplified version)', () => {
+    const src = [3, 3, 5, 1]
+    expect(simplifiedWiggleSort(src)).toEqual([1, 5, 3, 3])
+  })
+})

--- a/Sorts/test/SimplifiedWiggleSort.test.js
+++ b/Sorts/test/SimplifiedWiggleSort.test.js
@@ -1,7 +1,7 @@
 import { simplifiedWiggleSort } from '../SimplifiedWiggleSort.js'
 
 describe('simplified wiggle sort', () => {
-  test('given array of symbols [\'b\', \'a\', \'c\'] return wiggle sorted array [\'a\', \'c\', \'b\']', () => {
+  test('simplified wiggle sort for chars', () => {
     const src = ['a', 'b', 'c']
     expect(simplifiedWiggleSort(src)).toEqual(['a', 'c', 'b'])
   })
@@ -16,13 +16,8 @@ describe('simplified wiggle sort', () => {
     expect(simplifiedWiggleSort(src)).toEqual([1, 4, 1, 2, 1])
   })
 
-  test('simplified wiggle sort for [3, 5, 6, 1]', () => {
-    const src = [3, 5, 6, 1]
-    expect(simplifiedWiggleSort(src)).toEqual([3, 6, 1, 5])
-  })
-
-  test('simplified wiggle sort for [3, 3, 5, 1] (equal values next to ' +
-    'each other can not be avoided in simplified version)', () => {
+  test('simplified wiggle sort wich leads to equal values next to ' +
+    'each other', () => {
     const src = [3, 3, 5, 1]
     expect(simplifiedWiggleSort(src)).toEqual([1, 5, 3, 3])
   })

--- a/Sorts/test/SimplifiedWiggleSort.test.js
+++ b/Sorts/test/SimplifiedWiggleSort.test.js
@@ -16,7 +16,7 @@ describe('simplified wiggle sort', () => {
     expect(simplifiedWiggleSort(src)).toEqual([1, 4, 1, 2, 1])
   })
 
-  test('simplified wiggle sort wich leads to equal values next to ' +
+  test('simplified wiggle sort which leads to equal values next to ' +
     'each other', () => {
     const src = [3, 3, 5, 1]
     expect(simplifiedWiggleSort(src)).toEqual([1, 5, 3, 3])


### PR DESCRIPTION
# Welcome to the JavaScript community

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

Fixes: #988
Renamed the algorithm "simplified wiggle-sort", because traditional wiggle-sort demands arr[0] < arr[1] > arr[2] < arr[3] > arr[4] <... but this version only demands arr[0] <= arr[1] >= arr[2] <= arr[3] >= arr[4] <= …
For strict wiggle-sort there could be made an own implementation.

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
