### PR TITLE
Fixed spell mistake

### DIFF
--- a/String/FormatPhoneNumber.js
+++ b/String/FormatPhoneNumber.js
@@ -1,17 +1,16 @@
-// function that takes 10 digits and returns a string of the formatted phone number
-// e.g.: 1234567890 -> (123) 456-7890
-
-const formatPhoneNumber = (numbers) => {
-  const numbersString = numbers.toString()
-  if ((numbersString.length !== 10) || isNaN(numbersString)) {
+/**
+ * @description - function that takes 10 digits and returns a string of the formatted phone number e.g.: 1234567890 -> (123) 456-7890
+ * @param {string} phoneNumber
+ * @returns {string} - Formate to (XXX) XXX-XXXX pattern
+ */
+const formatPhoneNumber = (phoneNumber) => {
+  if ((phoneNumber.length !== 10) || isNaN(phoneNumber)) {
     // return "Invalid phone number."
-    throw new TypeError('Invalid phone number.')
+    throw new TypeError('Invalid phone number!')
   }
-  const arr = '(XXX) XXX-XXXX'.split('')
-  Array.from(numbersString).forEach(n => {
-    arr[arr.indexOf('X')] = n
-  })
-  return arr.join('')
+
+  let index = 0
+  return '(XXX) XXX-XXXX'.replace(/X/g, () => phoneNumber[index++])
 }
 
-export { formatPhoneNumber }
+export default formatPhoneNumber

--- a/String/FormatPhoneNumber.js
+++ b/String/FormatPhoneNumber.js
@@ -1,7 +1,7 @@
 /**
  * @description - function that takes 10 digits and returns a string of the formatted phone number e.g.: 1234567890 -> (123) 456-7890
  * @param {string} phoneNumber
- * @returns {string} - Formate to (XXX) XXX-XXXX pattern
+ * @returns {string} - Format to -> (XXX) XXX-XXXX pattern
  */
 const formatPhoneNumber = (phoneNumber) => {
   if ((phoneNumber.length !== 10) || isNaN(phoneNumber)) {

--- a/String/test/FormatPhoneNumber.test.js
+++ b/String/test/FormatPhoneNumber.test.js
@@ -1,23 +1,15 @@
-import { formatPhoneNumber } from '../FormatPhoneNumber'
+import formatPhoneNumber from '../FormatPhoneNumber'
 
-describe('PhoneNumberFormatting', () => {
+describe('Testing the formatPhoneNumber functions', () => {
+  it('expects to throw a type error', () => {
+    expect(() => formatPhoneNumber('1234567')).toThrow('Invalid phone number!')
+    expect(() => formatPhoneNumber('123456text')).toThrow('Invalid phone number!')
+    expect(() => formatPhoneNumber(12345)).toThrow('Invalid phone number!')
+  })
+
   it('expects to return the formatted phone number', () => {
     expect(formatPhoneNumber('1234567890')).toEqual('(123) 456-7890')
-  })
-
-  it('expects to return the formatted phone number', () => {
-    expect(formatPhoneNumber(1234567890)).toEqual('(123) 456-7890')
-  })
-
-  it('expects to throw a type error', () => {
-    expect(() => { formatPhoneNumber('1234567') }).toThrow('Invalid phone number.')
-  })
-
-  it('expects to throw a type error', () => {
-    expect(() => { formatPhoneNumber('123456text') }).toThrow('Invalid phone number.')
-  })
-
-  it('expects to throw a type error', () => {
-    expect(() => { formatPhoneNumber(12345) }).toThrow('Invalid phone number.')
+    expect(formatPhoneNumber('2124323322')).toEqual('(212) 432-3322')
+    expect(formatPhoneNumber('1721543455')).toEqual('(172) 154-3455')
   })
 })


### PR DESCRIPTION
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [x] Added correct spelling

### Checklist:

- [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [ ] This pull request is all my own work -- I have not plagiarized.
- [ ] I know that pull requests will not be merged if they fail the automated tests.
- [ ] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [ ] All new JavaScript files are placed inside an existing directory.
- [ ] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
