### PR TITLE
feat: AVLTree 100% test coverage

### DIFF
--- a/Data-Structures/Tree/AVLTree.js
+++ b/Data-Structures/Tree/AVLTree.js
@@ -90,14 +90,14 @@ const AVLTree = (function () {
   }
 
   // check if tree is balanced else balance it for insertion
-  const insertBalance = function (node, _val, balanceFactor) {
-    if (balanceFactor > 1 && _val < node._left._val) {
+  const insertBalance = function (node, _val, balanceFactor, tree) {
+    if (balanceFactor > 1 && tree._comp(_val, node._left._val) < 0) {
       return rightRotate(node) // Left Left Case
     }
-    if (balanceFactor < 1 && _val > node._right._val) {
+    if (balanceFactor < 1 && tree._comp(_val, node._right._val) > 0) {
       return leftRotate(node) // Right Right Case
     }
-    if (balanceFactor > 1 && _val > node._left._val) {
+    if (balanceFactor > 1 && tree._comp(_val, node._left._val) > 0) {
       node._left = leftRotate(node._left) // Left Right Case
       return rightRotate(node)
     }
@@ -140,7 +140,7 @@ const AVLTree = (function () {
     }
     updateHeight(root)
     const balanceFactor = getHeightDifference(root)
-    return isValidBalanceFactor(balanceFactor) ? root : insertBalance(root, val, balanceFactor)
+    return isValidBalanceFactor(balanceFactor) ? root : insertBalance(root, val, balanceFactor, tree)
   }
 
   // delete am element

--- a/Data-Structures/Tree/test/AVLTree.test.js
+++ b/Data-Structures/Tree/test/AVLTree.test.js
@@ -5,26 +5,38 @@ describe('AVLTree Implementation: ', () => {
   const dataList = []
   const demoData = [1, 4, 6, 22, 7, 99, 4, 66, 77, 98]
 
+  const avlStringTree = new AVLTree()
+  const collator = new Intl.Collator()
+  const stringData = ['S', 'W', 'z', 'B', 'a']
+
   beforeAll(() => {
     demoData.forEach(item => {
       if (avlTree.add(item)) {
         dataList.push(item)
       }
     })
+
+    avlStringTree._comp = collator.compare
+    stringData.forEach(item => avlStringTree.add(item))
   })
 
   it('checks if element is inserted properly', () => {
     expect(dataList.length).toEqual(avlTree.size)
+    expect(stringData.length).toEqual(avlStringTree.size)
   })
 
   it('search if inserted element is present', () => {
     demoData.forEach(data => {
       expect(avlTree.find(data)).toBeTruthy()
     })
+    stringData.forEach(data => {
+      expect(avlStringTree.find(data)).toBeTruthy()
+    })
   })
 
   it('deletes the inserted element', () => {
     const deleteElement = dataList[3]
     expect(avlTree.remove(deleteElement)).toBeTruthy()
+    expect(avlStringTree.remove(stringData[3])).toBeTruthy()
   })
 })

--- a/Data-Structures/Tree/test/AVLTree.test.js
+++ b/Data-Structures/Tree/test/AVLTree.test.js
@@ -3,11 +3,13 @@ import { AVLTree } from '../AVLTree'
 describe('AVLTree Implementation: ', () => {
   const avlTree = new AVLTree()
   const dataList = []
-  const demoData = [1, 4, 6, 22, 7, 99, 4, 66, 77, 98]
+  const demoData = [1, 4, 6, 22, 7, 99, 4, 66, 77, 98, 87, 54, 32, 15]
 
   const avlStringTree = new AVLTree()
   const collator = new Intl.Collator()
   const stringData = ['S', 'W', 'z', 'B', 'a']
+
+  const emptyTree = new AVLTree(collator.compare)
 
   beforeAll(() => {
     demoData.forEach(item => {
@@ -18,6 +20,11 @@ describe('AVLTree Implementation: ', () => {
 
     avlStringTree._comp = collator.compare
     stringData.forEach(item => avlStringTree.add(item))
+  })
+
+  it('delete and search from empty tree', () => {
+    expect(emptyTree.remove(0)).toBeFalsy()
+    expect(emptyTree.find(0)).toBeFalsy()
   })
 
   it('checks if element is inserted properly', () => {
@@ -34,9 +41,32 @@ describe('AVLTree Implementation: ', () => {
     })
   })
 
-  it('deletes the inserted element', () => {
-    const deleteElement = dataList[3]
-    expect(avlTree.remove(deleteElement)).toBeTruthy()
-    expect(avlStringTree.remove(stringData[3])).toBeTruthy()
+  it('delete element with two valid children', () => {
+    expect(avlTree.remove(77)).toBeTruthy()
   })
+
+  it('delete element missing L-child', () => {
+    expect(avlTree.remove(98)).toBeTruthy()
+  })
+
+  it('delete elements forcing single R-rotation', () => {
+    expect(avlTree.remove(99)).toBeTruthy()
+    expect(avlTree.remove(87)).toBeTruthy()
+  })
+
+  it('delete elements forcing R-rotation and L-rotation', () => {
+    expect(avlTree.remove(1)).toBeTruthy()
+    expect(avlTree.remove(4)).toBeTruthy()
+  })
+
+  it('delete elements forcing single L-rotation', () => {
+    expect(avlTree.remove(7)).toBeTruthy()
+    expect(avlTree.remove(15)).toBeTruthy()
+    expect(avlTree.remove(6)).toBeTruthy()
+  })
+
+  it('delete element forcing single L-rotation and R-rotation', () => {
+    expect(avlTree.remove(66)).toBeTruthy()
+  })
+
 })

--- a/Data-Structures/Tree/test/AVLTree.test.js
+++ b/Data-Structures/Tree/test/AVLTree.test.js
@@ -68,5 +68,4 @@ describe('AVLTree Implementation: ', () => {
   it('delete element forcing single L-rotation and R-rotation', () => {
     expect(avlTree.remove(66)).toBeTruthy()
   })
-
 })


### PR DESCRIPTION
Jest output prior to changes:

File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------|---------|----------|---------|---------|---------------------------------
All files   |   89.43 |    85.48 |     100 |   90.51 |
 AVLTree.js |   89.43 |    85.48 |     100 |   90.51 | ...,122-123,154-155,157-158,162

Jest output after changes:

File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------|---------|----------|---------|---------|-------------------
All files   |     100 |      100 |     100 |     100 |
 AVLTree.js |     100 |      100 |     100 |     100 |

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [ ] Add an algorithm?
- [ ] Fix a bug or typo in an existing algorithm?
- [x] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [ ] All new JavaScript files are placed inside an existing directory.
- [ ] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
