### PR TITLE
fix: build error due to FindLcm

### DIFF
--- a/Maths/FindLcm.js
+++ b/Maths/FindLcm.js
@@ -11,7 +11,7 @@
 
 'use strict'
 
-import { findHCF } from './findHcf'
+import { findHCF } from './FindHcf'
 
 // Find the LCM of two numbers.
 const findLcm = (num1, num2) => {


### PR DESCRIPTION
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.

It seems like for some reason, my recent PR broke the builds in the continuous integration, even though it passed locally and in the PR. Not 100% sure why it happened in one place but not the others, but in any event, it seems to be due to a capitalization error which I fix in this PR.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/JavaScript/pull/1223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

