### PR TITLE
Update removeAt function

### DIFF
--- a/Data-Structures/Linked-List/SinglyLinkedList.js
+++ b/Data-Structures/Linked-List/SinglyLinkedList.js
@@ -181,7 +181,7 @@ class LinkedList {
   // Removes the node at specified index
   removeAt (index) {
     // Check if index is present in list
-    if (index < 0 || index >= this.length) {
+    if (index < 0 || index > this.length) {
       throw new RangeError('Out of Range index')
     }
     if (index === 0) return this.removeFirst()


### PR DESCRIPTION
Previous removeAt function would throw a type error if the index is equals to the length of the list. This is because the first if statement in the removeAt function checked if the index is greater or equals to the length of the list whereas it should only check if the index is greater than the length and if true, it should throw a type error.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [x] Fix a bug or typo in the first if statement inside the removeAt() function
### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/JavaScript/pull/1264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

