### PR TITLE
test: skip test that's running way too long

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -9,10 +9,12 @@
   * [SumOfSubset](Backtracking/SumOfSubset.js)
 * **Bit-Manipulation**
   * [BinaryCountSetBits](Bit-Manipulation/BinaryCountSetBits.js)
+  * [IsPowerofFour](Bit-Manipulation/IsPowerofFour.js)
   * [IsPowerOfTwo](Bit-Manipulation/IsPowerOfTwo.js)
   * [LogTwo](Bit-Manipulation/LogTwo.js)
   * [NextPowerOfTwo](Bit-Manipulation/NextPowerOfTwo.js)
   * [SetBit](Bit-Manipulation/SetBit.js)
+  * [UniqueElementInAnArray](Bit-Manipulation/UniqueElementInAnArray.js)
 * **Cache**
   * [LFUCache](Cache/LFUCache.js)
   * [LRUCache](Cache/LRUCache.js)
@@ -270,6 +272,7 @@
   * [Problem017](Project-Euler/Problem017.js)
   * [Problem018](Project-Euler/Problem018.js)
   * [Problem020](Project-Euler/Problem020.js)
+  * [Problem021](Project-Euler/Problem021.js)
   * [Problem023](Project-Euler/Problem023.js)
   * [Problem025](Project-Euler/Problem025.js)
   * [Problem028](Project-Euler/Problem028.js)

--- a/Project-Euler/test/Problem044.test.js
+++ b/Project-Euler/test/Problem044.test.js
@@ -12,8 +12,8 @@ describe('checking nth prime number', () => {
     expect(problem44(1)).toBe(5482660)
   })
   // Project Euler Second Value for Condition Check
-  // FIXME skip this test for now because it runs very long and clogs up the CI & pre-commit hook
-  test('if the number is greater or equal to 2167', () => {
+  // Skipping this by default as it makes CI runs take way too long
+  test.skip('if the number is greater or equal to 2167', () => {
     expect(problem44(2167)).toBe(8476206790)
   })
 })


### PR DESCRIPTION
It's good to have the test there, but there's no use having it running for ~30 minutes or so in the GitHub Action

close #1193

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [x ] Fix a bug or typo in an existing algorithm?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
