### PR TITLE
fix: CI code style checking

### DIFF
--- a/.github/workflows/Ci.yml
+++ b/.github/workflows/Ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run test
 
       - name: 💄 Code style
-        run: npm run style
+        run: npm run check-style
 
   codespell:
     name: Check for spelling errors

--- a/Backtracking/MColoringProblem.js
+++ b/Backtracking/MColoringProblem.js
@@ -6,44 +6,44 @@
  * @see https://en.wikipedia.org/wiki/Graph_coloring
  */
 function mColoring(graph, m) {
-  const colors = new Array(graph.length).fill(0);
+  const colors = new Array(graph.length).fill(0)
 
   // Check if it's safe to color a vertex with a given color.
   function isSafe(vertex, color) {
     for (let i = 0; i < graph.length; i++) {
       if (graph[vertex][i] && colors[i] === color) {
-        return false;
+        return false
       }
     }
-    return true;
+    return true
   }
 
   // Use backtracking to try and color the graph.
   function solveColoring(vertex = 0) {
     if (vertex === graph.length) {
-      return true;
+      return true
     }
 
     for (let color = 1; color <= m; color++) {
       if (isSafe(vertex, color)) {
-        colors[vertex] = color;
-        
+        colors[vertex] = color
+
         if (solveColoring(vertex + 1)) {
-          return true;
+          return true
         }
 
         // If no solution, backtrack.
-        colors[vertex] = 0;
+        colors[vertex] = 0
       }
     }
-    return false;
+    return false
   }
 
   // If coloring is possible, return the colors.
   if (solveColoring()) {
-    return colors;
+    return colors
   }
-  return null;
+  return null
 }
 
-export { mColoring };
+export { mColoring }

--- a/Backtracking/tests/MColoringProblem.test.js
+++ b/Backtracking/tests/MColoringProblem.test.js
@@ -1,4 +1,4 @@
-import { mColoring } from '../MColoringProblem';
+import { mColoring } from '../MColoringProblem'
 
 describe('MColoringProblem', () => {
   it('should color a triangle with 3 colors', () => {
@@ -6,18 +6,18 @@ describe('MColoringProblem', () => {
       [0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]
-    ];
-    const solution = mColoring(graph, 3);
-    expect(solution).not.toBeNull();
-  });
+    ]
+    const solution = mColoring(graph, 3)
+    expect(solution).not.toBeNull()
+  })
 
   it('should not color a triangle with 2 colors', () => {
     const graph = [
       [0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]
-    ];
-    const solution = mColoring(graph, 2);
-    expect(solution).toBeNull();
-  });
-});
+    ]
+    const solution = mColoring(graph, 2)
+    expect(solution).toBeNull()
+  })
+})

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -10,6 +10,7 @@
   * [SumOfSubset](Backtracking/SumOfSubset.js)
 * **Bit-Manipulation**
   * [BinaryCountSetBits](Bit-Manipulation/BinaryCountSetBits.js)
+  * [GenerateSubSets](Bit-Manipulation/GenerateSubSets.js)
   * [GrayCodes](Bit-Manipulation/GrayCodes.js)
   * [IsPowerofFour](Bit-Manipulation/IsPowerofFour.js)
   * [IsPowerOfTwo](Bit-Manipulation/IsPowerOfTwo.js)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "vitest run",
     "test-watch": "vitest",
     "style": "npx prettier . --write",
+    "check-style": "npx prettier . --check",
     "prepare": "husky install"
   },
   "author": "TheAlgorithms",


### PR DESCRIPTION
This PR makes the CI use `--check` rather than `--write` so that CI fails if code isn't formatted properly.