### PR TITLE
fix: throw error instead of returning it in check case type functions

### DIFF
--- a/String/CheckFlatCase.js
+++ b/String/CheckFlatCase.js
@@ -12,7 +12,7 @@
 const checkFlatCase = (varname) => {
   // firstly, check that input is a string or not.
   if (typeof varname !== 'string') {
-    return new TypeError('Argument is not a string.')
+    throw new TypeError('Argument is not a string.')
   }
 
   const pat = /^[a-z]*$/

--- a/String/CheckKebabCase.js
+++ b/String/CheckKebabCase.js
@@ -10,7 +10,7 @@
 const CheckKebabCase = (varName) => {
   // firstly, check that input is a string or not.
   if (typeof varName !== 'string') {
-    return new TypeError('Argument is not a string.')
+    throw new TypeError('Argument is not a string.')
   }
 
   const pat = /(\w+)-(\w)([\w-]*)/

--- a/String/CheckPascalCase.js
+++ b/String/CheckPascalCase.js
@@ -10,7 +10,7 @@
 const CheckPascalCase = (VarName) => {
   // firstly, check that input is a string or not.
   if (typeof VarName !== 'string') {
-    return new TypeError('Argument is not a string.')
+    throw new TypeError('Argument is not a string.')
   }
 
   const pat = /^[A-Z][A-Za-z]*$/

--- a/String/test/CheckCamelCase.test.js
+++ b/String/test/CheckCamelCase.test.js
@@ -15,4 +15,8 @@ describe('checkCamelCase', () => {
     const result = checkCamelCase(value)
     expect(result).toBe(false)
   })
+
+  it('should throw when input is not a string', () => {
+    expect(() => checkCamelCase(100)).toThrowError()
+  })
 })

--- a/String/test/CheckFlatCase.test.js
+++ b/String/test/CheckFlatCase.test.js
@@ -15,4 +15,8 @@ describe('checkFlatCase function', () => {
     const actual = checkFlatCase('abcdefghijklmnopqrstuvwxyz')
     expect(actual).toBe(true)
   })
+
+  it('should throw when input is not a string', () => {
+    expect(() => checkFlatCase(100)).toThrowError()
+  })
 })

--- a/String/test/CheckKebabCase.test.js
+++ b/String/test/CheckKebabCase.test.js
@@ -11,3 +11,7 @@ test('CheckKebabCase(The Algorithms) -> false', () => {
   const res = CheckKebabCase(word)
   expect(res).toBeFalsy()
 })
+
+test('CheckKebabCase throws when input is not a string', () => {
+  expect(() => CheckKebabCase(100)).toThrowError()
+})

--- a/String/test/CheckPascalCase.test.js
+++ b/String/test/CheckPascalCase.test.js
@@ -17,3 +17,7 @@ test('CheckPascalCase(The Algorithms) -> false', () => {
   const res = CheckPascalCase(word)
   expect(res).toBeFalsy()
 })
+
+test('CheckPascalCase throws when input is not a string', () => {
+  expect(() => CheckPascalCase(100)).toThrowError()
+})


### PR DESCRIPTION
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

Errors should be thrown not returned. Additionally this PR adds _missing_ tests.

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] ~This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.~
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
