### PR TITLE
fix: properly floor the partial results in `DateDayDifference`

### DIFF
--- a/Conversions/DateDayDifference.js
+++ b/Conversions/DateDayDifference.js
@@ -14,21 +14,27 @@ const isLeap = (year) => {
   else return false
 }
 const DateToDay = (dd, mm, yyyy) => {
-  return Math.floor(
+  return (
     365 * (yyyy - 1) +
-      (yyyy - 1) / 4 -
-      (yyyy - 1) / 100 +
-      (yyyy - 1) / 400 +
-      dd +
-      (367 * mm - 362) / 12 +
-      (mm <= 2 ? 0 : isLeap(yyyy) ? -1 : -2)
+    Math.floor((yyyy - 1) / 4) -
+    Math.floor((yyyy - 1) / 100) +
+    Math.floor((yyyy - 1) / 400) +
+    dd +
+    Math.floor((367 * mm - 362) / 12) +
+    (mm <= 2 ? 0 : isLeap(yyyy) ? -1 : -2)
   )
+}
+
+const CheckDayAndMonth = (inDay, inMonth) => {
+  if (inDay <= 0 || inDay > 31 || inMonth <= 0 || inMonth > 12) {
+    throw new TypeError('Date is not valid.')
+  }
 }
 
 const DateDayDifference = (date1, date2) => {
   // firstly, check that both input are string or not.
   if (typeof date1 !== 'string' || typeof date2 !== 'string') {
-    return new TypeError('Argument is not a string.')
+    throw new TypeError('Argument is not a string.')
   }
   // extract the first date
   const [firstDateDay, firstDateMonth, firstDateYear] = date1
@@ -39,18 +45,9 @@ const DateDayDifference = (date1, date2) => {
     .split('/')
     .map((ele) => Number(ele))
   // check the both data are valid or not.
-  if (
-    firstDateDay < 0 ||
-    firstDateDay > 31 ||
-    firstDateMonth > 12 ||
-    firstDateMonth < 0 ||
-    secondDateDay < 0 ||
-    secondDateDay > 31 ||
-    secondDateMonth > 12 ||
-    secondDateMonth < 0
-  ) {
-    return new TypeError('Date is not valid.')
-  }
+  CheckDayAndMonth(firstDateDay, firstDateMonth)
+  CheckDayAndMonth(secondDateDay, secondDateMonth)
+
   return Math.abs(
     DateToDay(secondDateDay, secondDateMonth, secondDateYear) -
       DateToDay(firstDateDay, firstDateMonth, firstDateYear)

--- a/Conversions/test/DateDayDiffernce.test.js
+++ b/Conversions/test/DateDayDiffernce.test.js
@@ -1,21 +1,36 @@
 import { DateDayDifference } from '../DateDayDifference'
 
-test('The difference between 17/08/2002 & 10/10/2020 is 6630', () => {
-  const res = DateDayDifference('17/08/2002', '10/10/2020')
-  expect(res).toBe(6630)
-})
+describe('DateDayDifference', () => {
+  it.each([
+    ['17/08/2002', '10/10/2020', 6629],
+    ['18/02/2001', '16/03/2022', 7696],
+    ['11/11/2011', '12/12/2012', 397],
+    ['01/01/2001', '16/03/2011', 3726],
+    ['04/03/2024', '04/03/2024', 0],
+    ['03/03/2024', '04/03/2024', 1],
+    ['02/03/2024', '04/03/2024', 2],
+    ['01/03/2024', '04/03/2024', 3],
+    ['29/02/2024', '04/03/2024', 4],
+    ['04/03/2024', '04/03/2025', 365],
+    ['04/03/2023', '04/03/2024', 366]
+  ])(
+    'The difference between %s and %s is %i',
+    (firstDate, secondDate, expected) => {
+      expect(DateDayDifference(firstDate, secondDate)).toBe(expected)
+      expect(DateDayDifference(secondDate, firstDate)).toBe(expected)
+    }
+  )
 
-test('The difference between 18/02/2001 & 16/03/2022 is 7696', () => {
-  const res = DateDayDifference('18/02/2001', '16/03/2022')
-  expect(res).toBe(7696)
-})
+  it('should throw when any input is not a string', () => {
+    expect(() => DateDayDifference(10102024, '11/10/2024')).toThrowError()
+    expect(() => DateDayDifference('11/10/2024', 10102024)).toThrowError()
+  })
 
-test('The difference between 11/11/2011 & 12/12/2012 is 398', () => {
-  const res = DateDayDifference('11/11/2011', '12/12/2012')
-  expect(res).toBe(398)
-})
-
-test('The difference between 01/01/2001 & 16/03/2011 is 3727', () => {
-  const res = DateDayDifference('01/01/2001', '16/03/2011')
-  expect(res).toBe(3727)
+  it.each(['32/01/2000', '00/01/2000', '15/00/2000', '15/13/2000'])(
+    'should throw when input is not a correct date %s',
+    (wrongDate) => {
+      expect(() => DateDayDifference(wrongDate, '04/03/2024')).toThrowError()
+      expect(() => DateDayDifference('04/03/2024', wrongDate)).toThrowError()
+    }
+  )
 })


### PR DESCRIPTION
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

Currently `DateDayDifference('29/02/2024', '04/03/2024')` gives `5`. This PR fixes that. Further more:
- the errors now are _thrown_,
- the tests are reorganized; edited test cases were verified with the page linked in the docs,
- some minor refactoring was done.

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
