### PR TITLE
style: improve test names of `GetEuclidGCD`

### DIFF
--- a/Maths/test/GetEuclidGCD.test.js
+++ b/Maths/test/GetEuclidGCD.test.js
@@ -1,25 +1,22 @@
 import { GetEuclidGCD, GetEuclidGCDRecursive } from '../GetEuclidGCD'
 
-describe.each([GetEuclidGCD, GetEuclidGCDRecursive])(
-  '%# GetEuclidGCD',
-  (gcdFunction) => {
-    it.each([
-      [5, 20, 5],
-      [109, 902, 1],
-      [290, 780, 10],
-      [104, 156, 52],
-      [0, 100, 100],
-      [-5, 50, 5],
-      [0, 0, 0],
-      [1, 1234567, 1]
-    ])('returns correct result for %i and %j', (inputA, inputB, expected) => {
-      expect(gcdFunction(inputA, inputB)).toBe(expected)
-      expect(gcdFunction(inputB, inputA)).toBe(expected)
-    })
+describe.each([GetEuclidGCD, GetEuclidGCDRecursive])('%o', (gcdFunction) => {
+  it.each([
+    [5, 20, 5],
+    [109, 902, 1],
+    [290, 780, 10],
+    [104, 156, 52],
+    [0, 100, 100],
+    [-5, 50, 5],
+    [0, 0, 0],
+    [1, 1234567, 1]
+  ])('returns correct result for %i and %j', (inputA, inputB, expected) => {
+    expect(gcdFunction(inputA, inputB)).toBe(expected)
+    expect(gcdFunction(inputB, inputA)).toBe(expected)
+  })
 
-    it('should throw when any of the inputs is not a number', () => {
-      expect(() => gcdFunction('1', 2)).toThrowError()
-      expect(() => gcdFunction(1, '2')).toThrowError()
-    })
-  }
-)
+  it('should throw when any of the inputs is not a number', () => {
+    expect(() => gcdFunction('1', 2)).toThrowError()
+    expect(() => gcdFunction(1, '2')).toThrowError()
+  })
+})


### PR DESCRIPTION
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

While working on #1645 I have discovered `'%o'`. I decided to use it here. It should have been done in #1642.

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [x] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
