### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Keep GitHub Actions up to date with Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -397,6 +397,7 @@
 * **Timing-Functions**
   * [GetMonthDays](Timing-Functions/GetMonthDays.js)
   * [IntervalTimer](Timing-Functions/IntervalTimer.js)
+  * [ParseDate](Timing-Functions/ParseDate.js)
 * **Trees**
   * [BreadthFirstTreeTraversal](Trees/BreadthFirstTreeTraversal.js)
   * [DepthFirstSearch](Trees/DepthFirstSearch.js)


### PR DESCRIPTION
Auto-generates pull requests like:
* https://github.com/TheAlgorithms/Python/pulls?q=is%3Apr+author%3Aapp%2Fdependabot
* https://github.com/TheAlgorithms/Rust/pulls?q=is%3Apr+author%3Aapp%2Fdependabot

Fixes software supply chain safety warnings like at the bottom right of
https://github.com/TheAlgorithms/JavaScript/actions/runs/8960545794

* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)&nbsp;[know more](https://www.gitpod.io/docs/pull-requests/)

### Describe your change:

- [ ] Add an algorithm?
- [ ] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [ ] This pull request is all my own work -- I have not plagiarized.
- [ ] I know that pull requests will not be merged if they fail the automated tests.
- [ ] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [ ] All new JavaScript files are placed inside an existing directory.
- [ ] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
      **Example:**`UserProfile.js` is allowed but `userprofile.js`,`Userprofile.js`,`user-Profile.js`,`userProfile.js` are not
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
