### PR TITLE
added changes to your bellmanford.js

### DIFF
--- a/Graphs/BellmanFord.js
+++ b/Graphs/BellmanFord.js
@@ -34,11 +34,10 @@ function BellmanFord(graph, V, E, src, dest) {
   // Relax all edges |V| - 1 times. A simple
   // shortest path from src to any other
   // vertex can have at-most |V| - 1 edges
-  for (let i = 0; i < V - 1; i++) {
+  return dis[dest]
     for (let j = 0; j < E; j++) {
       if (dis[graph[j][0]] + graph[j][2] < dis[graph[j][1]]) {
         dis[graph[j][1]] = dis[graph[j][0]] + graph[j][2]
-      }
     }
   }
   // check for negative-weight cycles.


### PR DESCRIPTION
The change replaces the final loop with a direct return statement.
Previously, the code looped through all vertices to find the destination and then returned its distance. This loop was unnecessary because the destination index is already known.
By using:

return dis[dest]


the code becomes more efficient and readable.
It removes redundant iterations, reduces time complexity for that part from O(V) to O(1), and makes the function cleaner without affecting the output.