### PR TITLE
Remove extra test for Project Euler 044

### DIFF
--- a/Project-Euler/Problem044.js
+++ b/Project-Euler/Problem044.js
@@ -22,9 +22,17 @@ function problem44(k) {
 
     for (let j = k - 1; j > 0; j--) {
       const m = (j * (3 * j - 1)) / 2 // calculate all Pj < Pk
-      if (isPentagonal(n - m) && isPentagonal(n + m)) {
-        // Check sum and difference
-        return n - m // return D
+      // Check forward, checking n - m doubles work from previous iterations
+      const sum = n + m
+      if (isPentagonal(sum)) {
+        // Check sum - m = n
+        if (isPentagonal(sum + m)) {
+          return n // return D
+        }
+        // Check sum - n = m
+        if (isPentagonal(sum + n)) {
+          return m // return D
+        }
       }
     }
   }

--- a/Project-Euler/test/Problem044.test.js
+++ b/Project-Euler/test/Problem044.test.js
@@ -1,18 +1,15 @@
 import { problem44 } from '../Problem044.js'
 
-describe('checking nth prime number', () => {
+describe('Project Euler 044 - Pentagon numbers', () => {
   test('should be invalid input if number is negative', () => {
     expect(() => problem44(-3)).toThrowError('Invalid Input')
   })
+
   test('should be invalid input if number is 0', () => {
     expect(() => problem44(0)).toThrowError('Invalid Input')
   })
-  // Project Euler Condition Check
-  test('if the number is greater or equal to 1', () => {
+
+  test('solves the problem', () => {
     expect(problem44(1)).toBe(5482660)
-  })
-  // Project Euler Second Value for Condition Check
-  test('if the number is greater or equal to 2167', () => {
-    expect(problem44(2167)).toBe(8476206790)
   })
 })


### PR DESCRIPTION
The test for [Project Euler Problem 044](https://github.com/TheAlgorithms/JavaScript/blob/master/Project-Euler/Problem044.js) includes [a second test](https://github.com/TheAlgorithms/JavaScript/blob/master/Project-Euler/test/Problem044.test.js#L14-L17) that finds a second solution for the problem. This second solution test makes up for a third of the running time for the tests. I propose removing it.

### Describe your change:

- [ ] Add an algorithm?
- [ ] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

### Checklist:

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Javascript/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new JavaScript files are placed inside an existing directory.
- [x] All filenames should use the UpperCamelCase (PascalCase) style. There should be no spaces in filenames.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or another similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
